### PR TITLE
test(node): Initial automated test

### DIFF
--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,1 +1,2 @@
 src/bin/**
+.venv

--- a/node/src/main.c
+++ b/node/src/main.c
@@ -87,7 +87,7 @@ int main(void)
     lcd_pixmap(&dev, x1, x1 + RIOT_LOGO_WIDTH - 1, y1, y1 +  RIOT_LOGO_HEIGHT - 1,
                (const uint16_t *)picture);
 #endif
-    while (1) {}
+    puts("{\"result\": \"PASS\"}");
 
     return 0;
 }

--- a/node/src/requirements.txt
+++ b/node/src/requirements.txt
@@ -1,0 +1,3 @@
+pexpect==4.9.0
+ptyprocess==0.7.0
+pyserial==3.5

--- a/node/src/tests/01-run.py
+++ b/node/src/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import pexpect
+from testrunner import run
+
+
+def testfunc(child: pexpect.spawn):
+    child.expect("PASS")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
Here is an initial automated test. One can call:
```
make flash test
```

This will flash the device then reset it and check the output for the `PASS` string.