### PR TITLE
Add .gitattributes files to fix the platform if you're using Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+platform/**/* eol=lf


### PR DESCRIPTION
WARNING: Before executing this make sure that you haven't made any changes in the session since you'll be losing the changes due to the reset.

Based on: https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/#line-ending-transformations-concern-the-index

After adding this, you'll need to run the following commands:
```
git rm --cached -r .
git reset --hard
```

If you clone a new repository it should already be fixed.