### PR TITLE
Save device endpoint

### DIFF
--- a/web_backend/pom.xml
+++ b/web_backend/pom.xml
@@ -108,6 +108,11 @@
       <version>${jakarta.validation.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.hibernate.validator</groupId> <!-- Prevents creating entities with invalid attribute values -->
+      <artifactId>hibernate-validator</artifactId>
+      <version>8.0.0.Final</version>
+    </dependency>
+    <dependency>
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>

--- a/web_backend/src/main/java/haw/teamagochi/backend/device/dataaccess/model/DeviceEntity.java
+++ b/web_backend/src/main/java/haw/teamagochi/backend/device/dataaccess/model/DeviceEntity.java
@@ -3,15 +3,7 @@ import haw.teamagochi.backend.pet.dataaccess.model.PetEntity;
 import haw.teamagochi.backend.user.dataaccess.model.UserEntity;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.annotation.Nullable;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +24,10 @@ public class DeviceEntity {
   @Id
   @GeneratedValue
   private long id;
+
+  @Nullable
+  @Column(unique = true)
+  String identifier; // for device endpoint. Would be encrypted with DTLS?
 
   @NonNull
   @Size(max = 255)

--- a/web_backend/src/main/java/haw/teamagochi/backend/device/logic/UcManageDeviceImpl.java
+++ b/web_backend/src/main/java/haw/teamagochi/backend/device/logic/UcManageDeviceImpl.java
@@ -86,6 +86,9 @@ public class UcManageDeviceImpl implements UcManageDevice {
 
     DeviceEntity device = new DeviceEntity(deviceName, DeviceType.FROG);
     device.setOwner(owner);
+
+    device.setIdentifier(endpoint); // Jessica
+
     return ucManageDevice.create(device);
   }
 }

--- a/web_backend/src/test/java/haw/teamagochi/backend/PersistenceTest.java
+++ b/web_backend/src/test/java/haw/teamagochi/backend/PersistenceTest.java
@@ -1,0 +1,44 @@
+package haw.teamagochi.backend;
+
+import haw.teamagochi.backend.device.dataaccess.model.DeviceEntity;
+import haw.teamagochi.backend.device.dataaccess.model.DeviceType;
+import haw.teamagochi.backend.device.logic.UcFindDevice;
+import haw.teamagochi.backend.device.logic.UcManageDevice;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(H2DatabaseTestResource.class)
+public class PersistenceTest {
+
+    @Inject
+    UcFindDevice ucFindDevice;
+
+    @Inject
+    UcManageDevice ucManageDevice;
+
+    @AfterEach
+    void afterEach() {
+        ucManageDevice.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    // Hibernate automatically updates changes to persisted entities in DB.
+    // Only works when method marked @Transactional!
+    void testHibernateEntityManagement() {
+        DeviceEntity oldDevice = ucManageDevice.create("Old name", DeviceType.FROG);
+        oldDevice.setName("New name");
+        DeviceEntity newDevice = ucFindDevice.find(oldDevice.getId());
+        Assertions.assertEquals(oldDevice.getName(), newDevice.getName());
+
+    }
+
+}


### PR DESCRIPTION
See commit message for description of changes.

Saving the device endpoint is important for read and send operations from and to a device. So you know what device to adress.