### PR TITLE
platform: update objectsspecs

### DIFF
--- a/platform/data/objectmodels/32770.xml
+++ b/platform/data/objectmodels/32770.xml
@@ -13,7 +13,7 @@
         <Resources>
             <Item ID="0">
                 <Name>Status</Name>
-                <Operations>R</Operations>
+                <Operations>RW</Operations>
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>String</Type>


### PR DESCRIPTION
The device status must be writable by the backend. The question remains which values we accept as the status and how they are named. This should be defined before this PR is merged.
